### PR TITLE
Add `Number::format_i18n_non_trailing_zeros()` method to format internationally without trailing zeros.

### DIFF
--- a/src/Number.php
+++ b/src/Number.php
@@ -77,7 +77,7 @@ class Number implements JsonSerializable {
 	}
 
 	/**
-	 * Format i18n.
+	 * Format number with internationalization and without trailing zeros.
 	 *
 	 * @return string
 	 */

--- a/src/Number.php
+++ b/src/Number.php
@@ -77,6 +77,27 @@ class Number implements JsonSerializable {
 	}
 
 	/**
+	 * Format i18n.
+	 *
+	 * @return string
+	 */
+	public function format_i18n_non_trailing_zeros() {
+		$decimals = 0;
+		
+		$value = $this->get_value();
+
+		if ( false !== \strpos( $value, '.' ) ) {
+			$decimals = \substr( \strrchr( $value, '.' ), 1 );
+
+			$decimals = \rtrim( $decimals, '0' );
+
+			$decimals = \strlen( $decimals );
+		}
+
+		return $this->format_i18n( $decimals );
+	}
+
+	/**
 	 * Format.
 	 *
 	 * @param int         $decimals            Precision of the number of decimal places.

--- a/src/Number.php
+++ b/src/Number.php
@@ -82,16 +82,16 @@ class Number implements JsonSerializable {
 	 * @return string
 	 */
 	public function format_i18n_non_trailing_zeros() {
-		$decimals = 0;
-		
 		$value = $this->get_value();
 
-		if ( false !== \strpos( $value, '.' ) ) {
-			$decimals = \substr( \strrchr( $value, '.' ), 1 );
+		$decimals = 0;
 
-			$decimals = \rtrim( $decimals, '0' );
+		$decimal_pos = \strpos( $value, '.' );
 
-			$decimals = \strlen( $decimals );
+		if ( false !== $decimal_pos ) {
+			$decimal_part = \substr( $value, $decimal_pos + 1 );
+
+			$decimals = \strlen( \rtrim( $decimal_part, '0' ) );
 		}
 
 		return $this->format_i18n( $decimals );

--- a/src/Number.php
+++ b/src/Number.php
@@ -227,6 +227,15 @@ class Number implements JsonSerializable {
 	}
 
 	/**
+	 * Is whole number?
+	 *
+	 * @return bool
+	 */
+	public function is_whole_number() {
+		return (float) $this->to_int() === (float) $this->get_value();
+	}
+
+	/**
 	 * JSON serialize.
 	 *
 	 * @link https://www.php.net/manual/en/jsonserializable.jsonserialize.php


### PR DESCRIPTION
Related to https://github.com/pronamic/wp-pay-core/issues/230 and in use in https://github.com/pronamic/wp-pay-core/pull/231.